### PR TITLE
Categorize wasmCloud as Wasm orchestration

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -16458,7 +16458,7 @@ landscape:
             logo: spin.svg
             crunchbase: https://www.crunchbase.com/organization/fermyon-technologies
           - item:
-            name: Wasmcloud (Wasm)
+            name: wasmCloud (Wasm)
             homepage_url: https://wasmcloud.com/
             repo_url: https://github.com/wasmCloud/wasmCloud
             logo: wasmcloud.svg
@@ -16781,6 +16781,13 @@ landscape:
             repo_url: https://github.com/kuasar-io/kuasar
             logo: kuasar.svg
             crunchbase: https://www.crunchbase.com/organization/huawei-cloud
+            allow_duplicate_repo: true
+          - item:
+            name: wasmCloud (Wasm)
+            homepage_url: https://wasmcloud.com/
+            repo_url: https://github.com/wasmCloud/wasmCloud
+            logo: wasmcloud.svg
+            crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
             allow_duplicate_repo: true
           - item:
             name: runwasi


### PR DESCRIPTION
This PR just categorizes wasmCloud as a Wasm orchestration project which is a primary goal of the project. Please let me know if there's another piece of the landscape that I should modify!

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you added your SVG to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~30 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
